### PR TITLE
use correct size of package length

### DIFF
--- a/src/cargo/util/dependency_queue.rs
+++ b/src/cargo/util/dependency_queue.rs
@@ -196,7 +196,7 @@ impl<N: Hash + Eq + Clone, E: Eq + Hash + Clone, V> DependencyQueue<N, E, V> {
 
     /// Returns the number of remaining packages to be built.
     pub fn len(&self) -> usize {
-        self.dep_map.len()
+        self.dep_map.len() + self.ready.len()
     }
 
     /// Indicate that something has finished.


### PR DESCRIPTION
This fixes this panic that I've been seeing with cargo-batch after the last changes. It was suggested by claude code after I told it to debug the issue, and looking at the code I think the fix look good (and it does no longer crash).

Original panic: 
```
thread 'main' (681329) panicked at src/cargo/util/progress.rs:469:9:
assertion failed: cur <= max
stack backtrace:
   0:     0x560140a0bcc2 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::haa87a551a4affa55
   1:     0x560140a1ff8f - core::fmt::write::h80461e1e45e4fdd2
   2:     0x5601409ce4f1 - std::io::Write::write_fmt::h6e6c69b2d6337d9b
   3:     0x5601409de402 - std::sys::backtrace::BacktraceLock::print::hf67a46baa621998e
   4:     0x5601409e4fef - std::panicking::default_hook::{{closure}}::h391aa815d5e47ec8
   5:     0x5601409e4e49 - std::panicking::default_hook::hd6fdcf2489bb807d
   6:     0x5601409e5725 - std::panicking::panic_with_hook::h185ddfb86bf14d73
   7:     0x5601409e54d6 - std::panicking::panic_handler::{{closure}}::had89ddd01b6112c9
   8:     0x5601409de539 - std::sys::backtrace::__rust_end_short_backtrace::h5d0fc36eef7265ea
   9:     0x5601409c0ecd - __rustc[eb8946e36839644a]::rust_begin_unwind
  10:     0x560140a2ac00 - core::panicking::panic_fmt::h92c8e5abe71dd8d1
  11:     0x560140a2abdc - core::panicking::panic::ha264d2bb233f2b69
  12:     0x56013fb1dc6c - cargo::util::progress::State::tick::h31844476b6703d2c
  13:     0x56013fc44f16 - cargo::core::compiler::job_queue::DrainState::drain_the_queue::h210531c42a06f27d
  14:     0x56013fc4ea87 - cargo::core::compiler::job_queue::JobQueue::execute::h848bbbd1734d1721
  15:     0x56013fba4e13 - cargo::core::compiler::build_runner::BuildRunner::compile::h7f4846b0fbd5a1e8
  16:     0x56013fa37b2c - cargo_batch::main2::h6892f4f079a283c7
  17:     0x56013fa33dd9 - cargo_batch::main::h2c5c58fd34797901
  18:     0x56013fa5c5f3 - std::sys::backtrace::__rust_begin_short_backtrace::ha2a0032ad5fb2b7c
  19:     0x56013fa4c559 - std::rt::lang_start::{{closure}}::he9bcd2f9d24a2c69
  20:     0x5601409d01d0 - std::rt::lang_start_internal::h6ba36b077a531782
```